### PR TITLE
都道府県選択画面UI作成とnavigationbar修正

### DIFF
--- a/WeatherApp.xcodeproj/project.pbxproj
+++ b/WeatherApp.xcodeproj/project.pbxproj
@@ -377,6 +377,8 @@
 				INFOPLIST_FILE = WeatherApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIStatusBarHidden = NO;
+				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -407,6 +409,8 @@
 				INFOPLIST_FILE = WeatherApp/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIStatusBarHidden = NO;
+				INFOPLIST_KEY_UIStatusBarStyle = "";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/WeatherApp/Info.plist
+++ b/WeatherApp/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/WeatherApp/Info.plist
+++ b/WeatherApp/Info.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIViewControllerBasedStatusBarAppearance</key>
-	<false/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>

--- a/WeatherApp/ViewControllers/Main/MainViewController.swift
+++ b/WeatherApp/ViewControllers/Main/MainViewController.swift
@@ -17,6 +17,12 @@ class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        //tableViewスクロール時だけステータスバーがナビゲーションバー色になるのを防止する
+        self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
+        self.navigationController?.navigationBar.shadowImage = UIImage()
+        //tableViewスクロール時に色が変更されるのを防止する
+        self.navigationController?.navigationBar.barTintColor = .orange
+
         self.navigationController?.navigationBar.backgroundColor = .orange
         self.navigationController?.navigationBar.tintColor = .white
         self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]

--- a/WeatherApp/ViewControllers/Main/MainViewController.swift
+++ b/WeatherApp/ViewControllers/Main/MainViewController.swift
@@ -17,6 +17,13 @@ class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.navigationController?.navigationBar.backgroundColor = .orange
+        self.navigationController?.navigationBar.tintColor = .white
+        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
+        self.navigationItem.title = "Home"
+        //navigationBarの戻るボタンを隠す（スプラッシュ画面に戻らないように）
+        self.navigationItem.hidesBackButton = true
+
         selectButton.setup(image: UIImage(systemName: "list.bullet")!)
         getLocationButton.setup(image: UIImage(systemName: "location")!)
 

--- a/WeatherApp/ViewControllers/Main/MainViewController.swift
+++ b/WeatherApp/ViewControllers/Main/MainViewController.swift
@@ -17,15 +17,14 @@ class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        //tableViewスクロール時だけステータスバーがナビゲーションバー色になるのを防止する
-        self.navigationController?.navigationBar.setBackgroundImage(UIImage(), for: .default)
-        self.navigationController?.navigationBar.shadowImage = UIImage()
-        //tableViewスクロール時に色が変更されるのを防止する
-        self.navigationController?.navigationBar.barTintColor = .orange
-
-        self.navigationController?.navigationBar.backgroundColor = .orange
+        let appearance = UINavigationBarAppearance()
+        appearance.configureWithOpaqueBackground()
+        appearance.backgroundColor = .orange
+        appearance.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
+        appearance.backButtonAppearance.normal.titleTextAttributes = [.foregroundColor: UIColor.white]
+        self.navigationController?.navigationBar.scrollEdgeAppearance = appearance
+        self.navigationController?.navigationBar.standardAppearance = appearance
         self.navigationController?.navigationBar.tintColor = .white
-        self.navigationController?.navigationBar.titleTextAttributes = [NSAttributedString.Key.foregroundColor: UIColor.white]
         self.navigationItem.title = "Home"
         //navigationBarの戻るボタンを隠す（スプラッシュ画面に戻らないように）
         self.navigationItem.hidesBackButton = true

--- a/WeatherApp/ViewControllers/Select/SelectTableViewCell.xib
+++ b/WeatherApp/ViewControllers/Select/SelectTableViewCell.xib
@@ -17,14 +17,19 @@
                 <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="鹿児島県" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ugh-S6-4BS">
-                        <rect key="frame" x="16" y="12" width="288" height="21"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="鹿児島県" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ugh-S6-4BS">
+                        <rect key="frame" x="10" y="10" width="300" height="24"/>
                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                         <nil key="textColor"/>
                         <nil key="highlightedColor"/>
                     </label>
                 </subviews>
+                <constraints>
+                    <constraint firstAttribute="bottom" secondItem="ugh-S6-4BS" secondAttribute="bottom" constant="10" id="0lg-iK-BdD"/>
+                    <constraint firstItem="ugh-S6-4BS" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="ZRs-iK-ntC"/>
+                    <constraint firstItem="ugh-S6-4BS" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" constant="10" id="o02-zQ-bwm"/>
+                    <constraint firstAttribute="trailing" secondItem="ugh-S6-4BS" secondAttribute="trailing" constant="10" id="rVV-ig-zGz"/>
+                </constraints>
             </tableViewCellContentView>
             <viewLayoutGuide key="safeArea" id="njF-e1-oar"/>
             <connections>

--- a/WeatherApp/ViewControllers/Select/SelectView.xib
+++ b/WeatherApp/ViewControllers/Select/SelectView.xib
@@ -24,14 +24,6 @@
                     <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
-                <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" translatesAutoresizingMaskIntoConstraints="NO" id="Rli-OQ-OFE">
-                    <rect key="frame" x="0.0" y="406" width="375" height="44"/>
-                    <autoresizingMask key="autoresizingMask"/>
-                    <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Rli-OQ-OFE" id="eKk-Q5-sfR">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </tableViewCellContentView>
-                </tableViewCell>
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>

--- a/WeatherApp/ViewControllers/Select/SelectView.xib
+++ b/WeatherApp/ViewControllers/Select/SelectView.xib
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
-    <device id="retina6_12" orientation="portrait" appearance="light"/>
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
@@ -17,19 +17,11 @@
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view clearsContextBeforeDrawing="NO" contentMode="scaleToFill" id="i5M-Pr-FkT">
-            <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lbz-ki-Y4B">
-                    <rect key="frame" x="0.0" y="59" width="393" height="44"/>
-                    <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                    <items>
-                        <navigationItem title="都道府県の選択" id="UrO-eK-Bub"/>
-                    </items>
-                </navigationBar>
-                <tableView clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Itt-qy-zCM">
-                    <rect key="frame" x="16" y="103" width="351" height="715"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="-1" sectionFooterHeight="-1" estimatedSectionFooterHeight="-1" translatesAutoresizingMaskIntoConstraints="NO" id="Itt-qy-zCM">
+                    <rect key="frame" x="0.0" y="44" width="375" height="623"/>
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
                 <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" translatesAutoresizingMaskIntoConstraints="NO" id="Rli-OQ-OFE">
@@ -43,8 +35,14 @@
             </subviews>
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+            <constraints>
+                <constraint firstItem="Itt-qy-zCM" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="6R1-d0-cHx"/>
+                <constraint firstItem="Itt-qy-zCM" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="IQt-bJ-3r3"/>
+                <constraint firstItem="Itt-qy-zCM" firstAttribute="trailing" secondItem="fnl-2z-Ty3" secondAttribute="trailing" id="nai-x7-Bvh"/>
+                <constraint firstAttribute="bottom" secondItem="Itt-qy-zCM" secondAttribute="bottom" id="si0-cf-Bh2"/>
+            </constraints>
             <splitViewDetailSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
-            <point key="canvasLocation" x="57.251908396946561" y="20.422535211267608"/>
+            <point key="canvasLocation" x="56.799999999999997" y="20.239880059970016"/>
         </view>
     </objects>
     <resources>

--- a/WeatherApp/ViewControllers/Select/SelectView.xib
+++ b/WeatherApp/ViewControllers/Select/SelectView.xib
@@ -25,10 +25,10 @@
                     <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                 </tableView>
                 <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" translatesAutoresizingMaskIntoConstraints="NO" id="Rli-OQ-OFE">
-                    <rect key="frame" x="16" y="404" width="393" height="44"/>
+                    <rect key="frame" x="0.0" y="406" width="375" height="44"/>
                     <autoresizingMask key="autoresizingMask"/>
                     <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Rli-OQ-OFE" id="eKk-Q5-sfR">
-                        <rect key="frame" x="0.0" y="0.0" width="393" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </tableViewCellContentView>
                 </tableViewCell>

--- a/WeatherApp/ViewControllers/Select/SelectViewController.swift
+++ b/WeatherApp/ViewControllers/Select/SelectViewController.swift
@@ -25,6 +25,8 @@ class SelectViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        self.navigationItem.title = "都道府県の選択"
+
         selectTableView.register(UINib(nibName: "SelectTableViewCell", bundle: nil), forCellReuseIdentifier: "customCell")
 
         selectTableView.dataSource = self


### PR DESCRIPTION
## チケットへのリンク

issue #4 

## やったこと

- 都道府県作成画面のUI作成（オートレイアウトによる制約の追加）
- 上記に伴い、メイン画面でのナビゲーションバーも手直し（仕様書画面にあわせスプラッシュ画面への戻るButton削除、タイトルの追加、ナビゲーションバー及びタイトルの色変更を実施）

## やらないこと

- 詳細画面への遷移時の値渡し処理

## できるようになること（ユーザ目線）

なし

## できなくなること（ユーザ目線）

なし

## 動作確認

- シミュレータ（iPhone 14ProMax,SE)

## その他

- issueがUI作成とのことで、画面遷移時の値を渡す処理は未実装です。しかし、処理の実装も含んでのUI作成でしょうか？