### PR TITLE
Feature/display not get dialog

### DIFF
--- a/WeatherApp/Models/LocationManager.swift
+++ b/WeatherApp/Models/LocationManager.swift
@@ -11,7 +11,7 @@ protocol LocationManagerDelegate: AnyObject {
     func didUpdateLocation(_ location: CLLocation)
     func didFailWithError(_ error: Error)
 }
-
+/// シングルトン
 final class LocationManager: NSObject {
     private let locationManager = CLLocationManager()
     weak var delegate: LocationManagerDelegate?
@@ -22,13 +22,18 @@ final class LocationManager: NSObject {
         super.init()
         locationManager.delegate = self
     }
+    /// 位置情報取得許諾状態を表すプロパティ。許可されていればTrue
+    var isAuthorized: Bool {
+        let status = locationManager.authorizationStatus
+        return status == .authorizedAlways || status == .authorizedWhenInUse
+    }
 
     func requestLocationPermission() {
         locationManager.requestWhenInUseAuthorization()
     }
 
     func startUpdatingLocation() {
-        if locationManager.authorizationStatus == .authorizedAlways || locationManager.authorizationStatus == .authorizedWhenInUse {
+        if isAuthorized {
             print("アプリの位置情報取得が許可されています")
             locationManager.startUpdatingLocation()
         } else {

--- a/WeatherApp/ViewControllers/Main/MainViewController.swift
+++ b/WeatherApp/ViewControllers/Main/MainViewController.swift
@@ -98,7 +98,6 @@ extension MainViewController: LocationManagerDelegate {
     }
 
     func didFailWithError(_ error: Error) {
-        print("位置情報が取得できないため、遷移しません（のちにアラート実装）")
-//        displayNotGetLocationDialog()
+        print("位置情報が取得できないため、遷移しません")
     }
 }

--- a/WeatherApp/ViewControllers/Main/MainViewController.swift
+++ b/WeatherApp/ViewControllers/Main/MainViewController.swift
@@ -78,5 +78,15 @@ extension MainViewController: LocationManagerDelegate {
 
     func didFailWithError(_ error: Error) {
         print("位置情報が取得できないため、遷移しません（のちにアラート実装）")
+        displayNotGetLocationDialog()
+    }
+
+    func displayNotGetLocationDialog() {
+        let title = "位置情報取得失敗"
+        let message = "位置情報の取得ができません。設定を見直してください。"
+        let dialog = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let alertAction = UIAlertAction(title: "OK", style: .default)
+        dialog.addAction(alertAction)
+        self.present(dialog, animated: true, completion: nil)
     }
 }

--- a/WeatherApp/ViewControllers/Main/MainViewController.swift
+++ b/WeatherApp/ViewControllers/Main/MainViewController.swift
@@ -14,6 +14,7 @@ class MainViewController: UIViewController {
 
     private let buttonLayoutX: CGFloat = 100
     private let buttonLayoutY: CGFloat = 40
+    private let locationManager = CLLocationManager()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -58,6 +59,11 @@ class MainViewController: UIViewController {
     }
 
     @IBAction func tapLocationGetButton(_ sender: Any) {
+        // アプリへの位置情報許諾状況を確認し、許可されていなければダイアログ表示
+        guard locationManager.authorizationStatus == .authorizedAlways || locationManager.authorizationStatus == .authorizedWhenInUse else {
+            displayNotGetLocationDialog()
+            return
+        }
         if CLLocationManager.locationServicesEnabled() {
             print("デバイスの位置情報が取得可能です")
             LocationManager.shared.startUpdatingLocation()
@@ -65,6 +71,21 @@ class MainViewController: UIViewController {
             print("デバイスの位置情報が取得できません")
         }
 
+    }
+    /// 位置情報を取得できない場合のダイアログを表示するメソッド
+    func displayNotGetLocationDialog() {
+        let title = "位置情報取得失敗"
+        let message = "このアプリの位置情報取得が許可されていません。アプリの設定を見直してください。"
+        let dialog = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let closeAction = UIAlertAction(title: "閉じる", style: .default)
+        let settingAction = UIAlertAction(title: "設定", style: .default) {_ in
+            guard let url = URL(string: UIApplication.openSettingsURLString), UIApplication.shared.canOpenURL(url) else { return }
+            UIApplication.shared.open(url, options: [:], completionHandler: nil)
+
+        }
+        dialog.addAction(closeAction)
+        dialog.addAction(settingAction)
+        self.present(dialog, animated: true, completion: nil)
     }
 }
 
@@ -78,15 +99,6 @@ extension MainViewController: LocationManagerDelegate {
 
     func didFailWithError(_ error: Error) {
         print("位置情報が取得できないため、遷移しません（のちにアラート実装）")
-        displayNotGetLocationDialog()
-    }
-
-    func displayNotGetLocationDialog() {
-        let title = "位置情報取得失敗"
-        let message = "位置情報の取得ができません。設定を見直してください。"
-        let dialog = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        let alertAction = UIAlertAction(title: "OK", style: .default)
-        dialog.addAction(alertAction)
-        self.present(dialog, animated: true, completion: nil)
+//        displayNotGetLocationDialog()
     }
 }

--- a/WeatherApp/ViewControllers/Main/MainViewController.swift
+++ b/WeatherApp/ViewControllers/Main/MainViewController.swift
@@ -14,7 +14,6 @@ class MainViewController: UIViewController {
 
     private let buttonLayoutX: CGFloat = 100
     private let buttonLayoutY: CGFloat = 40
-    private let locationManager = CLLocationManager()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -60,7 +59,7 @@ class MainViewController: UIViewController {
 
     @IBAction func tapLocationGetButton(_ sender: Any) {
         // アプリへの位置情報許諾状況を確認し、許可されていなければダイアログ表示
-        guard locationManager.authorizationStatus == .authorizedAlways || locationManager.authorizationStatus == .authorizedWhenInUse else {
+        guard LocationManager.shared.isAuthorized else {
             displayNotGetLocationDialog()
             return
         }


### PR DESCRIPTION
## チケットへのリンク

- #9 

## やったこと

- 位置情報取得許可が出ていない場合に、ダイアログを表示する処理の実装

## やらないこと

- エラーハンドリング

## できるようになること（ユーザ目線）

- アプリの位置情報取得許可がないことがわかる
- 設定画面に遷移できる

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

- シミュレータiPhone SE
- 実機iPhone 13Pro

## その他

- ダイアログの表示メソッドは、Viewにかかる部分のため、メソッドとしての定義で問題ないでしょうか？
